### PR TITLE
Don't hard-code "/cache-enabler" in advanced-cache.php

### DIFF
--- a/advanced-cache.php
+++ b/advanced-cache.php
@@ -11,11 +11,11 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 /*
- * Set the CACHE_ENABLER_PLUGIN_DIR constant in your wp-config.php file if the plugin resides
+ * Set the CACHE_ENABLER_DIR constant in your wp-config.php file if the plugin resides
  * somewhere other than wp-content/plugins/cache-enabler/.
  */
-if ( defined( 'CACHE_ENABLER_PLUGIN_DIR' ) ) {
-    $ce_dir = CACHE_ENABLER_PLUGIN_DIR;
+if ( defined( 'CACHE_ENABLER_DIR' ) ) {
+    $ce_dir = CACHE_ENABLER_DIR;
 } else {
     $ce_dir = ( ( defined( 'WP_PLUGIN_DIR' ) ) ? WP_PLUGIN_DIR : WP_CONTENT_DIR . '/plugins' ) . '/cache-enabler';
 }

--- a/advanced-cache.php
+++ b/advanced-cache.php
@@ -10,7 +10,16 @@ if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 
-$ce_dir = ( ( defined( 'WP_PLUGIN_DIR' ) ) ? WP_PLUGIN_DIR : WP_CONTENT_DIR . '/plugins' ) . '/cache-enabler';
+/*
+ * Set the CACHE_ENABLER_PLUGIN_DIR constant in your wp-config.php file if the plugin resides
+ * somewhere other than wp-content/plugins/cache-enabler/.
+ */
+if ( defined( 'CACHE_ENABLER_PLUGIN_DIR' ) ) {
+    $ce_dir = CACHE_ENABLER_PLUGIN_DIR;
+} else {
+    $ce_dir = ( ( defined( 'WP_PLUGIN_DIR' ) ) ? WP_PLUGIN_DIR : WP_CONTENT_DIR . '/plugins' ) . '/cache-enabler';
+}
+
 $ce_engine_file = $ce_dir . '/inc/cache_enabler_engine.class.php';
 $ce_disk_file   = $ce_dir . '/inc/cache_enabler_disk.class.php';
 


### PR DESCRIPTION
When the `advanced-cache.php` file is loaded, it was previously looking for `WP_PLUGIN_DIR . '/cache-enabler'`, which would prevent page caching from working if the plugin was not installed here for whatever reason.

This PR enables the path to be adjusted by defining a `CACHE_ENABLER_PLUGIN_DIR` constant in a site's `wp-config.php` file.