### PR TITLE
Prevent undefined variable notices regarding $wp_config_file

### DIFF
--- a/inc/cache_enabler_disk.class.php
+++ b/inc/cache_enabler_disk.class.php
@@ -1023,10 +1023,12 @@ final class Cache_Enabler_Disk {
         } elseif ( @file_exists( dirname( ABSPATH ) . '/wp-config.php' ) && ! @file_exists( dirname( ABSPATH ) . '/wp-settings.php' ) ) {
             // config file resides one level above ABSPATH but is not part of another installation
             $wp_config_file = dirname( ABSPATH ) . '/wp-config.php';
+        } else {
+            $wp_config_file = false;
         }
 
         // check if config file can be written to
-        if ( ! is_writable( $wp_config_file ) ) {
+        if ( ! $wp_config_file || ! is_writable( $wp_config_file ) ) {
             return;
         }
 


### PR DESCRIPTION
`Cache_Enabler_Disk::set_wp_cache_constant()` checks two locations for a valid `wp-config.php` file, but if neither `ABSPATH . '/wp-config.php'` nor `dirname(ABSPATH) . '/wp-config.php'` exist, the `is_writable()` check will cause an "Undefined variable" notice.

This commit adds a default value of `false` and will return early if the variable either uses this default or represents a non-writable file.

Upstream PR: keycdn/cache-enabler#210