### PR TITLE
Re-work some of the bootstrapping to avoid conflicts

### DIFF
--- a/cache-enabler.php
+++ b/cache-enabler.php
@@ -1,6 +1,6 @@
 <?php
 /*
-Plugin Name: Cache Enabler
+Plugin Name: Cache Enabler (Nexcess)
 Text Domain: cache-enabler
 Description: Simple and fast WordPress caching plugin.
 Author: KeyCDN
@@ -52,26 +52,20 @@ define( 'CE_DIR', CACHE_ENABLER_DIR );
 
 // hooks
 add_action( 'plugins_loaded', array( 'Cache_Enabler', 'init' ) );
-register_activation_hook( __FILE__, array( 'Cache_Enabler', 'on_activation' ) );
-register_deactivation_hook( __FILE__, array( 'Cache_Enabler', 'on_deactivation' ) );
-register_uninstall_hook( __FILE__, array( 'Cache_Enabler', 'on_uninstall' ) );
 
 // register autoload
-spl_autoload_register( 'cache_enabler_autoload' );
-
-// load required classes
-function cache_enabler_autoload( $class_name ) {
+spl_autoload_register( function ( $class_name ) {
     // check if classes were loaded in advanced-cache.php
-    if ( in_array( $class_name, array( 'Cache_Enabler', 'Cache_Enabler_Engine', 'Cache_Enabler_Disk' ) ) && ! class_exists( $class_name ) ) {
+    if ( in_array( $class_name, [ 'Cache_Enabler', 'Cache_Enabler_Engine', 'Cache_Enabler_Disk' ], true ) ) {
         require_once sprintf(
             '%s/inc/%s.class.php',
             CACHE_ENABLER_DIR,
             strtolower( $class_name )
         );
     }
-}
+} );
 
 // load WP-CLI command
-if ( defined( 'WP_CLI' ) && WP_CLI && class_exists( 'WP_CLI' ) ) {
+if ( defined( 'WP_CLI' ) && WP_CLI && ! class_exists( 'Cache_Enabler_CLI' ) ) {
     require_once CACHE_ENABLER_DIR . '/inc/cache_enabler_cli.class.php';
 }

--- a/inc/cache_enabler.class.php
+++ b/inc/cache_enabler.class.php
@@ -1680,22 +1680,6 @@ final class Cache_Enabler {
         <div id="cache_enabler_settings" class="wrap">
             <h1><?php esc_html_e( 'Page Cache', 'cache-enabler' ); ?></h1>
 
-            <?php
-            if ( Cache_Enabler_Engine::$settings['enabled'] && ( ! defined( 'WP_CACHE' ) || ! WP_CACHE ) ) {
-                printf(
-                    '<div class="notice notice-warning"><p>%s</p></div>',
-                    sprintf(
-                        // translators: 1. Cache Enabler 2. define( 'WP_CACHE', true ); 3. wp-config.php 4. require_once ABSPATH . 'wp-settings.php';
-                        esc_html__( '%1$s requires %2$s to be set. Please set this in the %3$s file (must be before %4$s).', 'cache-enabler' ),
-                        '<strong>Cache Enabler</strong>',
-                        "<code>define( 'WP_CACHE', true );</code>",
-                        '<code>wp-config.php</code>',
-                        "<code>require_once ABSPATH . 'wp-settings.php';</code>"
-                    )
-                );
-            }
-            ?>
-
             <form method="post" action="options.php">
                 <?php settings_fields( 'cache_enabler' ); ?>
                 <table class="form-table">


### PR DESCRIPTION
If the upstream version of Cache Enabler is activated, the `cache_enabler_autoload()` function definition would cause a fatal error, preventing plugin activation.

While this version will still generate notices about already-defined constants, this will at least enable users to switch to the canonical Cache Enabler. Additionally, it suppresses a notice on the settings screen that can sometimes show erroneously immediately after the page cache has been enabled.