### PR TITLE
Explicitly set the path for loading the Cache Enabler engine in advanced-cache.php

### DIFF
--- a/advanced-cache.php
+++ b/advanced-cache.php
@@ -1,25 +1,14 @@
 <?php
+
 /**
- * Cache Enabler advanced cache
- *
- * @since   1.2.0
- * @change  1.7.0
+ * Advanced page cache drop-in.
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 
-/*
- * Set the CACHE_ENABLER_DIR constant in your wp-config.php file if the plugin resides
- * somewhere other than wp-content/plugins/cache-enabler/.
- */
-if ( defined( 'CACHE_ENABLER_DIR' ) ) {
-    $cache_enabler_dir = CACHE_ENABLER_DIR;
-} else {
-    $cache_enabler_dir = ( ( defined( 'WP_PLUGIN_DIR' ) ) ? WP_PLUGIN_DIR : WP_CONTENT_DIR . '/plugins' ) . '/cache-enabler';
-}
-
+$cache_enabler_dir         = WP_CONTENT_DIR . '/mu-plugins/nexcess-mapps/vendor/keycdn/cache-enabler';
 $cache_enabler_engine_file = $cache_enabler_dir . '/inc/cache_enabler_engine.class.php';
 $cache_enabler_disk_file   = $cache_enabler_dir . '/inc/cache_enabler_disk.class.php';
 


### PR DESCRIPTION
Without this, the advanced-cache.php drop-in will explicitly look for files in the Cache Enabler plugin instead of the bundled version.