### PR TITLE
Automatically clear expired caches via WP-Cron

### DIFF
--- a/inc/cache_enabler.class.php
+++ b/inc/cache_enabler.class.php
@@ -66,6 +66,7 @@ final class Cache_Enabler {
         add_action( 'cache_enabler_clear_site_cache_by_blog_id', array( __CLASS__, 'clear_site_cache_by_blog_id' ) );
         add_action( 'cache_enabler_clear_page_cache_by_post_id', array( __CLASS__, 'clear_page_cache_by_post_id' ) );
         add_action( 'cache_enabler_clear_page_cache_by_url', array( __CLASS__, 'clear_page_cache_by_url' ) );
+        add_action( 'cache_enabler_clear_expired_cache', array( 'Cache_Enabler_Disk', 'clear_expired_cache' ) );
         add_action( 'ce_clear_cache', array( __CLASS__, 'clear_complete_cache' ) ); // deprecated in 1.6.0
         add_action( 'ce_clear_post_cache', array( __CLASS__, 'clear_page_cache_by_post_id' ) ); // deprecated in 1.6.0
 
@@ -116,6 +117,11 @@ final class Cache_Enabler {
             add_action( 'admin_notices', array( __CLASS__, 'requirements_check' ) );
             add_action( 'admin_notices', array( __CLASS__, 'cache_cleared_notice' ) );
             add_action( 'network_admin_notices', array( __CLASS__, 'cache_cleared_notice' ) );
+        }
+
+        // cron events
+        if ( ! wp_next_scheduled( 'cache_enabler_clear_expired_cache' ) ) {
+            wp_schedule_event( time(), 'hourly', 'cache_enabler_clear_expired_cache' );
         }
     }
 

--- a/inc/cache_enabler_disk.class.php
+++ b/inc/cache_enabler_disk.class.php
@@ -281,6 +281,25 @@ final class Cache_Enabler_Disk {
 
 
     /**
+     * clear all expired files from the cache
+     */
+
+    public static function clear_expired_cache() {
+        $cache_objects = self::get_site_objects( home_url() );
+        $cache_dir     = trailingslashit( self::get_cache_file_dir( home_url() ) );
+
+        // Remove expired cache items.
+        array_walk( $cache_objects, function ( $cache_object ) use ( $cache_dir ) {
+            $file = $cache_dir . $cache_object;
+
+            if ( self::cache_expired( $file ) ) {
+                unlink( $file );
+            }
+        } );
+    }
+
+
+    /**
      * create file for cache
      *
      * @since   1.0.0


### PR DESCRIPTION
Currently, sites that use the Apache rewrites to bypass PHP will not clear out expired cached files, as noted here: https://www.keycdn.com/support/wordpress-cache-enabler-plugin#will-cached-page-expiration-still-work-if-the-advanced-configuration-is-used

This PR registers an hourly cron job that iterates through the disk-based cache and removes cache files that have passed their expiration time.

Upstream PR: keycdn/cache-enabler#223.