### PR TITLE
Version 1.8.0+mapps

### DIFF
--- a/advanced-cache.php
+++ b/advanced-cache.php
@@ -10,9 +10,9 @@ if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 
-/*
- * Set the CACHE_ENABLER_DIR constant in your wp-config.php file if the plugin resides
- * somewhere other than wp-content/plugins/cache-enabler/.
+/**
+ * set the CACHE_ENABLER_DIR constant without trailing slash in your wp-config.php file if the plugin resides
+ * somewhere other than path/to/wp-content/plugins/cache-enabler
  */
 if ( defined( 'CACHE_ENABLER_DIR' ) ) {
     $cache_enabler_dir = CACHE_ENABLER_DIR;

--- a/cache-enabler.php
+++ b/cache-enabler.php
@@ -62,7 +62,7 @@ spl_autoload_register( 'cache_enabler_autoload' );
 // load required classes
 function cache_enabler_autoload( $class_name ) {
     // check if classes were loaded in advanced-cache.php
-    if ( in_array( $class_name, array( 'Cache_Enabler', 'Cache_Enabler_Engine', 'Cache_Enabler_Disk' ) ) && ! class_exists( $class_name ) ) {
+    if ( in_array( $class_name, array( 'Cache_Enabler', 'Cache_Enabler_Engine', 'Cache_Enabler_Disk' ), true ) && ! class_exists( $class_name ) ) {
         require_once sprintf(
             '%s/inc/%s.class.php',
             CACHE_ENABLER_DIR,

--- a/cache-enabler.php
+++ b/cache-enabler.php
@@ -6,7 +6,7 @@ Description: Simple and fast WordPress caching plugin.
 Author: KeyCDN
 Author URI: https://www.keycdn.com
 License: GPLv2 or later
-Version: 1.7.0
+Version: 1.7.1
 */
 
 /*
@@ -32,7 +32,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 // constants
-define( 'CACHE_ENABLER_VERSION', '1.7.0' );
+define( 'CACHE_ENABLER_VERSION', '1.7.1' );
 define( 'CACHE_ENABLER_MIN_PHP', '5.6' );
 define( 'CACHE_ENABLER_MIN_WP', '5.1' );
 define( 'CACHE_ENABLER_FILE', __FILE__ );

--- a/cache-enabler.php
+++ b/cache-enabler.php
@@ -6,7 +6,7 @@ Description: Simple and fast WordPress caching plugin.
 Author: KeyCDN
 Author URI: https://www.keycdn.com
 License: GPLv2 or later
-Version: 1.6.2
+Version: 1.7.0
 */
 
 /*
@@ -32,7 +32,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 // constants
-define( 'CACHE_ENABLER_VERSION', '1.6.2' );
+define( 'CACHE_ENABLER_VERSION', '1.7.0' );
 define( 'CACHE_ENABLER_MIN_PHP', '5.6' );
 define( 'CACHE_ENABLER_MIN_WP', '5.1' );
 define( 'CACHE_ENABLER_FILE', __FILE__ );

--- a/cache-enabler.php
+++ b/cache-enabler.php
@@ -6,7 +6,7 @@ Description: Simple and fast WordPress caching plugin.
 Author: KeyCDN
 Author URI: https://www.keycdn.com
 License: GPLv2 or later
-Version: 1.7.1+mapps
+Version: 1.8.0+mapps
 */
 
 /*
@@ -32,7 +32,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 // constants
-define( 'CACHE_ENABLER_VERSION', '1.7.1-mapps' );
+define( 'CACHE_ENABLER_VERSION', '1.8.0+mapps' );
 define( 'CACHE_ENABLER_MIN_PHP', '5.6' );
 define( 'CACHE_ENABLER_MIN_WP', '5.1' );
 define( 'CACHE_ENABLER_FILE', __FILE__ );

--- a/inc/cache_enabler.class.php
+++ b/inc/cache_enabler.class.php
@@ -66,6 +66,7 @@ final class Cache_Enabler {
         add_action( 'cache_enabler_clear_site_cache_by_blog_id', array( __CLASS__, 'clear_site_cache_by_blog_id' ) );
         add_action( 'cache_enabler_clear_page_cache_by_post_id', array( __CLASS__, 'clear_page_cache_by_post_id' ) );
         add_action( 'cache_enabler_clear_page_cache_by_url', array( __CLASS__, 'clear_page_cache_by_url' ) );
+        add_action( 'cache_enabler_clear_expired_cache', array( 'Cache_Enabler_Disk', 'clear_expired_cache' ) );
         add_action( 'ce_clear_cache', array( __CLASS__, 'clear_complete_cache' ) ); // deprecated in 1.6.0
         add_action( 'ce_clear_post_cache', array( __CLASS__, 'clear_page_cache_by_post_id' ) ); // deprecated in 1.6.0
 
@@ -116,6 +117,11 @@ final class Cache_Enabler {
             add_action( 'admin_notices', array( __CLASS__, 'requirements_check' ) );
             add_action( 'admin_notices', array( __CLASS__, 'cache_cleared_notice' ) );
             add_action( 'network_admin_notices', array( __CLASS__, 'cache_cleared_notice' ) );
+        }
+
+        // cron events
+        if ( ! wp_next_scheduled( 'cache_enabler_clear_expired_cache' ) ) {
+            wp_schedule_event( time(), 'hourly', 'cache_enabler_clear_expired_cache' );
         }
     }
 

--- a/inc/cache_enabler_disk.class.php
+++ b/inc/cache_enabler_disk.class.php
@@ -885,8 +885,8 @@ final class Cache_Enabler_Disk {
             if ( $filesystem === false ) {
                 if ( is_wp_error( $wp_filesystem->errors ) && $wp_filesystem->errors->has_errors() ) {
                     throw new \RuntimeException(
-                        $wp_filesystem->get_error_message,
-                        ( is_numeric( $wp_error->get_error_code() ) ) ? (int) $wp_error->get_error_code() : 0
+                        $wp_filesystem->errors->get_error_message(),
+                        ( is_numeric( $wp_filesystem->errors->get_error_code() ) ) ? (int) $wp_filesystem->errors->get_error_code() : 0
                     );
                 }
 

--- a/inc/cache_enabler_disk.class.php
+++ b/inc/cache_enabler_disk.class.php
@@ -281,6 +281,25 @@ final class Cache_Enabler_Disk {
 
 
     /**
+     * clear all expired files from the cache
+     */
+
+    public static function clear_expired_cache() {
+        $cache_objects = self::get_site_objects( home_url() );
+        $cache_dir     = trailingslashit( self::get_cache_file_dir( home_url() ) );
+
+        // Remove expired cache items.
+        array_walk( $cache_objects, function ( $cache_object ) use ( $cache_dir ) {
+            $file = $cache_dir . $cache_object;
+
+            if ( self::cache_expired( $file ) ) {
+                unlink( $file );
+            }
+        } );
+    }
+
+
+    /**
      * create file for cache
      *
      * @since   1.0.0

--- a/inc/cache_enabler_disk.class.php
+++ b/inc/cache_enabler_disk.class.php
@@ -770,7 +770,7 @@ final class Cache_Enabler_Disk {
      * get site file system objects
      *
      * @since   1.6.0
-     * @change  1.6.0
+     * @change  1.7.0
      *
      * @param   string  $site_url      site URL
      * @return  array   $site_objects  site objects
@@ -797,10 +797,10 @@ final class Cache_Enabler_Disk {
             $blog_paths = Cache_Enabler::get_blog_paths();
 
             // check if main site in subdirectory network
-            if ( ! in_array( $blog_path, $blog_paths ) ) {
+            if ( ! in_array( $blog_path, $blog_paths, true ) ) {
                 foreach ( $site_objects as $key => $site_object ) {
                     // delete site object if it does not belong to main site
-                    if ( in_array( '/' . $site_object . '/', $blog_paths ) ) {
+                    if ( in_array( '/' . $site_object . '/', $blog_paths, true ) ) {
                         unset( $site_objects[ $key ] );
                     }
                 }

--- a/inc/cache_enabler_engine.class.php
+++ b/inc/cache_enabler_engine.class.php
@@ -280,7 +280,7 @@ final class Cache_Enabler_Engine {
      * check if page is excluded from cache
      *
      * @since   1.5.0
-     * @change  1.5.3
+     * @change  1.7.0
      *
      * @return  boolean  true if page is excluded from the cache, false otherwise
      */
@@ -289,7 +289,10 @@ final class Cache_Enabler_Engine {
 
         // if post ID excluded
         if ( ! empty( self::$settings['excluded_post_ids'] ) && function_exists( 'is_singular' ) && is_singular() ) {
-            if ( in_array( get_queried_object_id(), (array) explode( ',', self::$settings['excluded_post_ids'] ) ) ) {
+            $post_id = get_queried_object_id();
+            $excluded_post_ids = array_map( 'absint', (array) explode( ',', self::$settings['excluded_post_ids'] ) );
+
+            if ( in_array( $post_id, $excluded_post_ids, true ) ) {
                 return true;
             }
         }

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: keycdn
 Tags: cache, caching, performance, gzip, webp, speed
 Requires at least: 5.1
-Tested up to: 5.6
+Tested up to: 5.7
 Requires PHP: 5.6
 Stable tag: trunk
 License: GPLv2 or later
@@ -54,6 +54,19 @@ Cache Enabler captures page contents and saves it as a static HTML file on the s
 
 
 == Changelog ==
+
+= 1.7.0 =
+* Update cache clearing for theme, plugin, post, and upgrade actions (#215 and #216)
+* Update cache handling with cache keys (#211)
+* Update settings file deletion handling (#205)
+* Update output buffer handling (#203)
+* Update removing CSS and JavaScript comments during HTML minification (#202)
+* Update WebP URL conversion for installations in a subdirectory (#198)
+* Add `CACHE_ENABLER_DIR` as definable plugin directory constant (#195 @stevegrunwell)
+* Add explicit directory access permissions (#194 @stevegrunwell)
+* Add exclusive lock when writing files (#191 @nawawi)
+* Fix clear cache request handling (#212)
+* Fix getting `wp-config.php` (#210 @stevegrunwell)
 
 = 1.6.2 =
 * Fix removing CSS and JavaScript comments during HTML minification (#188)

--- a/readme.txt
+++ b/readme.txt
@@ -55,6 +55,9 @@ Cache Enabler captures page contents and saves it as a static HTML file on the s
 
 == Changelog ==
 
+= 1.7.1 =
+* Fix directory creation handling (#221 @stevegrunwell)
+
 = 1.7.0 =
 * Update cache clearing for theme, plugin, post, and upgrade actions (#215 and #216)
 * Update cache handling with cache keys (#211)


### PR DESCRIPTION
## Added

* Automatically clear expired caches via WP-Cron (#10)

## Updated

* Pull in upstream updates for [Cache Enabler 1.7.1](https://github.com/keycdn/cache-enabler/releases/tag/1.7.1)