### PR TITLE
Don't attempt to unlink cache contents that aren't files

### DIFF
--- a/inc/cache_enabler_disk.class.php
+++ b/inc/cache_enabler_disk.class.php
@@ -292,7 +292,7 @@ final class Cache_Enabler_Disk {
         array_walk( $cache_objects, function ( $cache_object ) use ( $cache_dir ) {
             $file = $cache_dir . $cache_object;
 
-            if ( self::cache_expired( $file ) ) {
+            if ( is_file( $file ) && self::cache_expired( $file ) ) {
                 unlink( $file );
             }
         } );


### PR DESCRIPTION
This extends #10 based on [this feedback](https://github.com/keycdn/cache-enabler/pull/223#issuecomment-806283191) so we only try to call `unlink()` on files.