### PR TITLE
Don't set 'enabled' to 1 by default

### DIFF
--- a/inc/cache_enabler.class.php
+++ b/inc/cache_enabler.class.php
@@ -633,7 +633,7 @@ final class Cache_Enabler {
     private static function get_default_settings( $settings_type = null ) {
 
         $system_default_settings = array(
-            'enabled'             => 1,
+            'enabled'             => 0,
             'version'             => (string) CACHE_ENABLER_VERSION,
             'permalink_structure' => (string) self::get_permalink_structure(),
         );


### PR DESCRIPTION
Within the Nexcess version, we'll explicitly activate.