### PR TITLE
Version 1.9.0+mapps

### DIFF
--- a/cache-enabler.php
+++ b/cache-enabler.php
@@ -6,7 +6,7 @@ Description: Simple and fast WordPress caching plugin.
 Author: KeyCDN
 Author URI: https://www.keycdn.com
 License: GPLv2 or later
-Version: 1.7.1
+Version: 1.7.2
 */
 
 /*
@@ -32,7 +32,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 // constants
-define( 'CACHE_ENABLER_VERSION', '1.7.1' );
+define( 'CACHE_ENABLER_VERSION', '1.7.2' );
 define( 'CACHE_ENABLER_MIN_PHP', '5.6' );
 define( 'CACHE_ENABLER_MIN_WP', '5.1' );
 define( 'CACHE_ENABLER_FILE', __FILE__ );

--- a/cache-enabler.php
+++ b/cache-enabler.php
@@ -6,7 +6,7 @@ Description: Simple and fast WordPress caching plugin.
 Author: KeyCDN
 Author URI: https://www.keycdn.com
 License: GPLv2 or later
-Version: 1.8.0+mapps
+Version: 1.9.0+mapps
 */
 
 /*
@@ -32,7 +32,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 // constants
-define( 'CACHE_ENABLER_VERSION', '1.8.0+mapps' );
+define( 'CACHE_ENABLER_VERSION', '1.9.0+mapps' );
 define( 'CACHE_ENABLER_MIN_PHP', '5.6' );
 define( 'CACHE_ENABLER_MIN_WP', '5.1' );
 define( 'CACHE_ENABLER_FILE', __FILE__ );

--- a/inc/cache_enabler.class.php
+++ b/inc/cache_enabler.class.php
@@ -750,7 +750,7 @@ final class Cache_Enabler {
      * add plugin metadata in the plugins list table
      *
      * @since   1.0.0
-     * @change  1.7.0
+     * @change  1.7.2
      *
      * @param   array   $plugin_meta  plugin metadata, including the version, author, author URI, and plugin URI
      * @param   string  $plugin_file  path to the plugin file relative to the plugins directory
@@ -767,7 +767,7 @@ final class Cache_Enabler {
         // append metadata
         $plugin_meta = wp_parse_args(
             array(
-                '<a href="https://www.keycdn.com/support/wordpress-cache-enabler-plugin" target="_blank" rel="nofollow noopener">Documentation</a>',
+                '<a href="https://www.keycdn.com/support/wordpress-cache-enabler-plugin" target="_blank" rel="nofollow noopener">' . esc_html__( 'Documentation', 'cache-enabler' ) . '</a>',
             ),
             $plugin_meta
         );

--- a/inc/cache_enabler_disk.class.php
+++ b/inc/cache_enabler_disk.class.php
@@ -912,7 +912,7 @@ final class Cache_Enabler_Disk {
      * makes directory recursively based on directory path
      *
      * @since   1.7.0
-     * @change  1.7.0
+     * @change  1.7.2
      *
      * @param   string   $dir  directory path to create
      * @return  boolean        true if the directory either already exists or was created and has the correct permissions, false otherwise
@@ -920,11 +920,13 @@ final class Cache_Enabler_Disk {
 
     private static function mkdir_p( $dir ) {
 
-        $parent_dir = dirname( $dir );
-        $fs = self::get_filesystem();
+        $fs          = self::get_filesystem();
+        $mode_octal  = apply_filters( 'cache_enabler_mkdir_mode', 0755 );
+        $mode_string = decoct( $mode_octal ); // get last three digits (e.g. '755')
+        $parent_dir  = dirname( $dir );
 
-        // check if directory and its parent have 755 permissions
-        if ( $fs->is_dir( $dir ) && $fs->getchmod( $dir ) === '755' && $fs->getchmod( $parent_dir ) === '755' ) {
+        // check if directory and its parent have correct permissions
+        if ( $fs->is_dir( $dir ) && $fs->getchmod( $dir ) === $mode_string && $fs->getchmod( $parent_dir ) === $mode_string ) {
             return true;
         }
 
@@ -934,13 +936,13 @@ final class Cache_Enabler_Disk {
         }
 
         // check parent directory permissions
-        if ( $fs->getchmod( $parent_dir ) !== '755' ) {
-            return $fs->chmod( $parent_dir, 0755, true );
+        if ( $fs->getchmod( $parent_dir ) !== $mode_string ) {
+            return $fs->chmod( $parent_dir, $mode_octal, true );
         }
 
         // check directory permissions
-        if ( $fs->getchmod( $dir ) !== '755' ) {
-            return $fs->chmod( $dir, 0755 );
+        if ( $fs->getchmod( $dir ) !== $mode_string ) {
+            return $fs->chmod( $dir, $mode_octal );
         }
 
         return true;

--- a/readme.txt
+++ b/readme.txt
@@ -55,6 +55,10 @@ Cache Enabler captures page contents and saves it as a static HTML file on the s
 
 == Changelog ==
 
+= 1.7.2 =
+* Update string to be translatable (#235 @timse201)
+* Add `cache_enabler_mkdir_mode` filter hook (#233)
+
 = 1.7.1 =
 * Fix directory creation handling (#221 @stevegrunwell)
 


### PR DESCRIPTION
Update the codebase to include changes from version 1.7.2 of [the KeyCDN repo](https://github.com/keycdn/cache-enabler).

[See all differences between the fork and upstream](https://github.com/keycdn/cache-enabler/compare/1.7.2...nexcess:release/v1.9.0+mapps).